### PR TITLE
Support XHTML self-closing tags

### DIFF
--- a/lib/simple-dom/html-serializer.js
+++ b/lib/simple-dom/html-serializer.js
@@ -3,7 +3,9 @@ function HTMLSerializer(voidMap) {
 }
 
 HTMLSerializer.prototype.openTag = function(element) {
-  return '<' + element.nodeName.toLowerCase() + this.attributes(element.attributes) + '>';
+  var tag = element.nodeName.toLowerCase(),
+      attributes = this.attributes(element.attributes)
+  return '<' + tag + attributes + (this.isVoid(element) ? ' />': '>');
 };
 
 HTMLSerializer.prototype.closeTag = function(element) {


### PR DESCRIPTION
This changes the HTMLSerializer to emit XHTML styled self-closing tags, instead of the HTML variant. It shouldn't change anything on the outside, but if you want to serve your app with `application/xhtml-xml` now you can. I use it to catch any HTML errors early on, and it might have a positive impact on parsing performance in the browser.