### PR TITLE
Fix document node constructor

### DIFF
--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -5,7 +5,7 @@ import Comment from './document/comment';
 import DocumentFragment from './document/document-fragment';
 
 function Document() {
-  this.nodeConstructor(this, 9, '#document', null);
+  this.nodeConstructor(9, '#document', null);
   this.documentElement = new Element('html');
   this.body = new Element('body');
   this.documentElement.appendChild(this.body);

--- a/test/document-test.js
+++ b/test/document-test.js
@@ -1,0 +1,14 @@
+import Document from 'simple-dom/document';
+
+QUnit.module('Document');
+
+QUnit.test("creating a document node", function(assert) {
+  var document = new Document();
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+  assert.strictEqual(document.nodeType, 9, "document has node type of 9");
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName
+  assert.strictEqual(document.nodeName, "#document", "document node has the name #document");
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue
+  assert.strictEqual(document.nodeValue, null, "for the document itself, nodeValue returns null");
+});


### PR DESCRIPTION
Looks like this was using `apply` at some point and was missed in the conversion of the other node types.