### PR TITLE
Clear previous sibling when inserting node

### DIFF
--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -96,6 +96,8 @@ Node.prototype.insertBefore = function(node, refNode) {
   if (previousSibling) {
     previousSibling.nextSibling = node;
     node.previousSibling = previousSibling;
+  }else{
+    node.previousSibling = null
   }
 
   refNode.previousSibling = node;

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -1,0 +1,22 @@
+import Node from 'simple-dom/document/node';
+
+QUnit.module('Node');
+
+QUnit.test("#insertBefore", function(assert) {
+  var body = new Node(1, 'body');
+  var div = new Node(1, 'div');
+  var span = new Node(1, 'span');
+  var ul = new Node(1, 'ul');
+  span.previousSibling = new Node(1, 'p');
+  body.appendChild(div);
+
+  body.insertBefore(span, div);
+  assert.strictEqual(span.parentNode, body, "nodes parent is set");
+  assert.strictEqual(span.previousSibling, null, "nodes previous sibling is cleared");
+  assert.strictEqual(span.nextSibling, div, "nodes next sibling is set");
+  assert.strictEqual(div.previousSibling, span, "next sibling's previous sibling is set");
+  assert.strictEqual(div.nextSibling, null, "next sibling's next sibling is set");
+  assert.strictEqual(div.parentNode, body, "next sibling's parent is set");
+  assert.strictEqual(body.firstChild, span, "parents first child is set");
+  assert.strictEqual(body.lastChild, div, "parents last child is set");
+});


### PR DESCRIPTION
Fixes infinite loop in Ember FastBoot rendering caused by loops in the nextSibling/previousSibling relationship.

Makes [this test](https://github.com/emberjs/ember.js/blob/2b76aa07476f15804b381e052f19999c5cf85fd0/tests/node/app-boot-test.js#L210) pass. 
Also part of [this issue](https://github.com/emberjs/ember.js/issues/11115).