### PR TITLE
HTMLSerializer should not serialize a node's siblings

### DIFF
--- a/lib/simple-dom/html-serializer.js
+++ b/lib/simple-dom/html-serializer.js
@@ -93,15 +93,14 @@ HTMLSerializer.prototype.serialize = function(node) {
   next = node.firstChild;
   if (next) {
     buffer += this.serialize(next);
+
+    while(next = next.nextSibling) {
+      buffer += this.serialize(next);
+    }
   }
 
   if (node.nodeType === 1 && !this.isVoid(node)) {
     buffer += this.closeTag(node);
-  }
-
-  next = node.nextSibling;
-  if (next) {
-    buffer += this.serialize(next);
   }
 
   return buffer;

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -10,15 +10,45 @@ QUnit.module('Serializer', {
   }
 });
 
-QUnit.test('serializes correctly', function (assert) {
+QUnit.test('serializes single element correctly', function (assert) {
+  var actual = this.serializer.serialize(element('div'));
+  assert.equal(actual, '<div></div>');
+});
+
+QUnit.test('serializes single void element correctly', function (assert) {
+  var actual = this.serializer.serialize(element('img', { src: 'foo' }));
+  assert.equal(actual, '<img src="foo">');
+});
+
+QUnit.test('serializes complex tree correctly', function (assert) {
   var actual = this.serializer.serialize(fragment(
-    element('div', { id:'foo' },
+    element('div', { id: 'foo' },
       element('b', {},
         text('Foo & Bar')
-      )
+      ),
+      text('!'),
+      element('img', { src: 'foo' })
     )
   ));
-  assert.equal(actual, '<div id="foo"><b>Foo &amp; Bar</b></div>');
+  assert.equal(actual, '<div id="foo"><b>Foo &amp; Bar</b>!<img src="foo"></div>');
+});
+
+QUnit.test('does not serialize siblings of an element', function (assert) {
+  var html = element('html');
+  var head = element('head');
+  var body = element('body');
+
+  head.appendChild(element('meta', { content: 'foo' }));
+  head.appendChild(element('meta', { content: 'bar' }));
+
+  html.appendChild(head);
+  html.appendChild(body);
+
+  var actual = this.serializer.serialize(head);
+  assert.equal(actual, '<head><meta content="foo"><meta content="bar"></head>');
+
+  actual = this.serializer.serialize(body);
+  assert.equal(actual, '<body></body>');
 });
 
 // SimpleDOM supports an extension of the DOM API that allows inserting strings of


### PR DESCRIPTION
Currently, if I create a new Element and serialize it, I get it's siblings too.

```js
var documentElement = new Element('html');
var head = new Element('head');
var body = new Element('body');
documentElement.appendChild(head);
documentElement.appendChild(body);

new HTMLSerializer.serialize(head); // => <head><head><body></body>
```