### PR TITLE
casting `attrValue` as string to handle numbers set as attribute values

### DIFF
--- a/lib/simple-dom/html-serializer.js
+++ b/lib/simple-dom/html-serializer.js
@@ -23,7 +23,7 @@ HTMLSerializer.prototype.attributes = function(namedNodeMap) {
 };
 
 HTMLSerializer.prototype.escapeAttrValue = function(attrValue) {
-  return attrValue.replace(/[&"]/g, function(match) {
+  return String(attrValue).replace(/[&"]/g, function(match) {
     switch(match) {
       case '&':
         return '&amp;';

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -15,6 +15,11 @@ QUnit.test('serializes single element correctly', function (assert) {
   assert.equal(actual, '<div></div>');
 });
 
+QUnit.test('serializes element with attribute number value correctly', function (assert) {
+  var actual = this.serializer.serialize(element('div', {"height": 500}));
+  assert.equal(actual, '<div height="500"></div>');
+});
+
 QUnit.test('serializes single void element correctly', function (assert) {
   var actual = this.serializer.serialize(element('img', { src: 'foo' }));
   assert.equal(actual, '<img src="foo">');


### PR DESCRIPTION
I ran into this issue using the [riotjs `render`](https://muut.com/riotjs/guide/#server-side) method which depends on `simple-dom` for serializing tags.

My riot tag:

    <dashboard-graph height={500}></dashboard-graph>

Running a [tape](https://github.com/substack/tape) test:

	var riot = require('riot')
	var tag = require('../../app/tags/dashboard/dashboard.tag')
	var test = require('tape')
	var html = riot.render(tag)

	test('dashboard', function (t) {
  		"use strict"
		t.ok(html, 'dashboard tag mounted')
		t.end()
	})

Would return this error.

	node_modules/riot/node_modules/simple-dom/dist/simple-dom.js:418
      return attrValue.replace(/[&"]/g, function(match) {
                       ^
	TypeError: attrValue.replace is not a function
