### PR TITLE
expose serializer method for child nodes

### DIFF
--- a/lib/simple-dom/html-serializer.js
+++ b/lib/simple-dom/html-serializer.js
@@ -68,9 +68,21 @@ HTMLSerializer.prototype.comment = function(comment) {
   return '<!--'+comment.nodeValue+'-->';
 };
 
+HTMLSerializer.prototype.serializeChildren = function(node) {
+  var buffer = '';
+  var next = node.firstChild;
+  if (next) {
+    buffer += this.serialize(next);
+
+    while(next = next.nextSibling) {
+      buffer += this.serialize(next);
+    }
+  }
+  return buffer;
+};
+
 HTMLSerializer.prototype.serialize = function(node) {
   var buffer = '';
-  var next;
 
   // open
   switch (node.nodeType) {
@@ -90,14 +102,7 @@ HTMLSerializer.prototype.serialize = function(node) {
       break;
   }
 
-  next = node.firstChild;
-  if (next) {
-    buffer += this.serialize(next);
-
-    while(next = next.nextSibling) {
-      buffer += this.serialize(next);
-    }
-  }
+  buffer += this.serializeChildren(node);
 
   if (node.nodeType === 1 && !this.isVoid(node)) {
     buffer += this.closeTag(node);

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -56,6 +56,20 @@ QUnit.test('does not serialize siblings of an element', function (assert) {
   assert.equal(actual, '<body></body>');
 });
 
+QUnit.test('serializes children but not self', function (assert) {
+  var actual = this.serializer.serializeChildren(fragment(
+    element('div', { id: 'foo' },
+      element('b', {},
+        text('Foo & Bar')
+      ),
+      text('!'),
+      element('img', { src: 'foo' })
+    )
+  ).firstChild);
+  assert.equal(actual, '<b>Foo &amp; Bar</b>!<img src="foo">');
+});
+
+
 // SimpleDOM supports an extension of the DOM API that allows inserting strings of
 // unparsed, raw HTML into the document. When the document is subsequently serialized,
 // the raw text of the HTML nodes is inserted into the HTML.


### PR DESCRIPTION
Fastboot needs to serialize the contents of the body & head elements, but not those tags themselves.  Currently those tags are included in the output generated by serialize leading to nested body & head tags (as seen [here](https://github.com/tildeio/ember-cli-fastboot/pull/66#issuecomment-143107666)).  This PR exposes a `serializeChildren` method to enable this behavior.  I'm glad to update/take a different approach if a different solution is preferred.